### PR TITLE
Do not parse strings with 4 digits (fixes #54)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,13 @@ module.exports = (function () {
         utc: false
     };
 
-    function isISO8601String(dateString) {
-        return (typeof dateString === 'string') && moment(dateString, moment.ISO_8601, true).isValid();
+    function isDateString(dateString) {
+        return (typeof dateString === 'string') && moment(dateString, moment.ISO_8601, true).isValid() && dateString.length >= 6;
     }
 
     function fnReviver(reviver) {
         return function (key, value) {
-            if (isISO8601String(value)) {
+            if (isDateString(value)) {
                 value = moment(value).toDate();
             }
             if (reviver) {

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,11 @@ describe('JSON stringify date', function () {
             res.should.have.property('d');
             res.d.should.be.instanceof(Date);
         });
+        it('should not parse a 4 digit string', function () {
+            var res = JSONStringifyDate.parse('{"d":"10101"}');
+            res.should.have.property('d');
+            res.d.should.be.instanceof(String);
+        });
     });
     describe('#getReviver', function () {
         describe('without customization', function () {


### PR DESCRIPTION
### Description
This is fixing a bug (#54) that a string with 4 digits will be parsed to date incorrectly

### Notes
N/A
