### PR TITLE
Add a test:release in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "should": "^13.2.3"
   },
   "scripts": {
-    "preversion": "npm test",
+    "preversion": "npm test:release",
     "postversion": "npm run changelog && npm run retag && npm run push",
-    "test": "npm run test:lint && npm run test:coverage && npm run test:build && npm run test:node && npm run test:browser",
+    "test": "npm run test:release && npm run test:browser",
+    "test:release": "npm run test:lint && npm run test:coverage && npm run test:build && npm run test:node",
     "test:coverage": "nyc npm run test:node",
     "test:node": "mocha",
     "test:browser": "mocha-chrome test/index.html",


### PR DESCRIPTION
### Description
Idea here is to not test if a browser.js was committed or not, given we will now (#79) commit as part of release process.

### Notes
N/A
